### PR TITLE
Add JpegLSMetadata

### DIFF
--- a/src/JpegLSFormat.cs
+++ b/src/JpegLSFormat.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Team CharLS.
 // SPDX-License-Identifier: BSD-3-Clause
 
-using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats;
 
 namespace CharLS.Managed.ImageSharp;
@@ -9,7 +8,7 @@ namespace CharLS.Managed.ImageSharp;
 /// <summary>
 /// Registers the image encoders, decoders and mime type detectors for the jpeg format.
 /// </summary>
-public sealed class JpegLSFormat : IImageFormat<JpegMetadata>
+public sealed class JpegLSFormat : IImageFormat<JpegLSMetadata>
 {
     private JpegLSFormat()
     {
@@ -33,5 +32,5 @@ public sealed class JpegLSFormat : IImageFormat<JpegMetadata>
     public IEnumerable<string> FileExtensions => JpegLSConstants.FileExtensions;
 
     /// <inheritdoc/>
-    public JpegMetadata CreateDefaultFormatMetadata() => new(); // TODO
+    public JpegLSMetadata CreateDefaultFormatMetadata() => new();
 }

--- a/src/JpegLSMetadata.cs
+++ b/src/JpegLSMetadata.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+using SixLabors.ImageSharp;
+
+namespace CharLS.Managed.ImageSharp;
+
+/// <summary>
+/// Provides JPEG-LS specific metadata information for the image.
+/// </summary>
+public sealed class JpegLSMetadata : IDeepCloneable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JpegLSMetadata"/> class.
+    /// </summary>
+    public JpegLSMetadata()
+    {
+    }
+
+    /// <inheritdoc />
+    public IDeepCloneable DeepClone() => new JpegLSMetadata();
+}

--- a/test/JpegLSDecoderTest.cs
+++ b/test/JpegLSDecoderTest.cs
@@ -13,14 +13,14 @@ public class JpegLSDecoderTest
     public void DecodeMonochromeImage()
     {
         Configuration configuration = new(new JpegLSConfigurationModule());
-        DecoderOptions options = new DecoderOptions { Configuration = configuration };
-        using Image image = Image.Load(options, "test-images/tulips-gray-8bit-512-512-hp-encoder.jls");
+        var options = new DecoderOptions { Configuration = configuration };
+        using var image = Image.Load(options, "test-images/tulips-gray-8bit-512-512-hp-encoder.jls");
 
         Assert.Equal(512, image.Width);
         Assert.Equal(512, image.Height);
         Assert.Equal(8, image.PixelType.BitsPerPixel);
 
-        using Image expected = Image.Load("test-images/tulips-gray-8bit-512-512.pgm");
+        using var expected = Image.Load("test-images/tulips-gray-8bit-512-512.pgm");
         Compare(expected.CloneAs<L8>(), image.CloneAs<L8>());
     }
 

--- a/test/JpegLSFormatTest.cs
+++ b/test/JpegLSFormatTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Team CharLS.
 // SPDX-License-Identifier: BSD-3-Clause
 
-using SixLabors.ImageSharp.Formats;
-
 namespace CharLS.Managed.ImageSharp.Test;
 
 public class JpegLSFormatTest
@@ -10,7 +8,7 @@ public class JpegLSFormatTest
     [Fact]
     public void InstanceHasExpectedJpegLSValues()
     {
-        IImageFormat imageFormat = JpegLSFormat.Instance;
+        var imageFormat = JpegLSFormat.Instance;
 
         Assert.Equal("JPEG-LS", imageFormat.Name);
         Assert.Equal("image/jls", imageFormat.DefaultMimeType);
@@ -18,5 +16,7 @@ public class JpegLSFormatTest
         Assert.Equal("image/jls", imageFormat.MimeTypes.First());
         Assert.Single(imageFormat.FileExtensions);
         Assert.Equal("jls", imageFormat.FileExtensions.First());
+
+        Assert.NotNull(imageFormat.CreateDefaultFormatMetadata());
     }
 }

--- a/test/JpegLSImageFormatDetectorTest.cs
+++ b/test/JpegLSImageFormatDetectorTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace CharLS.Managed.ImageSharp.Test;
+
+public class JpegLSImageFormatDetectorTest
+{
+    [Fact]
+    public void HeaderSizeIs4()
+    {
+        var imageFormatDetector = new JpegLSImageFormatDetector();
+        Assert.Equal(4, imageFormatDetector.HeaderSize);
+    }
+
+    [Fact]
+    public void TryDetectFormatValid()
+    {
+        var imageFormatDetector = new JpegLSImageFormatDetector();
+
+        var header = new byte[] { 0xFF, 0xD8, 0xFF, 0xC3 };
+        bool result = imageFormatDetector.TryDetectFormat(header, out var imageFormat);
+
+        Assert.True(result);
+        Assert.NotNull(imageFormat);
+    }
+
+    [Fact]
+    public void TryDetectFormatNotEnoughBytes()
+    {
+        var imageFormatDetector = new JpegLSImageFormatDetector();
+
+        var header = new byte[] { 0xFF, 0xD8 };
+        bool result = imageFormatDetector.TryDetectFormat(header, out var imageFormat);
+
+        Assert.False(result);
+        Assert.Null(imageFormat);
+    }
+
+    [Fact]
+    public void TryDetectFormatNoMarkersInside()
+    {
+        var imageFormatDetector = new JpegLSImageFormatDetector();
+
+        var header = new byte[] { 0xFF, 0xD8, 0xFF, 0xD9 };
+        bool result = imageFormatDetector.TryDetectFormat(header, out var imageFormat);
+
+        Assert.False(result);
+        Assert.Null(imageFormat);
+    }
+
+    [Fact]
+    public void TryDetectFormatBadVariants()
+    {
+        var imageFormatDetector = new JpegLSImageFormatDetector();
+
+        var header = new byte[] { 0x00, 0xD8, 0xFF, 0xD9 };
+        bool result = imageFormatDetector.TryDetectFormat(header, out var imageFormat);
+
+        Assert.False(result);
+        Assert.Null(imageFormat);
+
+        header = [0xFF, 0xD9, 0xFF, 0xD9];
+        result = imageFormatDetector.TryDetectFormat(header, out _);
+        Assert.False(result);
+    }
+}

--- a/test/JpegLSMetadataTest.cs
+++ b/test/JpegLSMetadataTest.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+using SixLabors.ImageSharp;
+
+namespace CharLS.Managed.ImageSharp.Test;
+
+public sealed class JpegLSMetadataTest
+{
+    [Fact]
+    public void Create()
+    {
+        var jpegLSMetadata = new JpegLSMetadata();
+        Assert.NotNull(jpegLSMetadata);
+    }
+
+    [Fact]
+    public void Clone()
+    {
+        IDeepCloneable jpegLSMetadata = new JpegLSMetadata();
+
+        var clone = jpegLSMetadata.DeepClone();
+        Assert.NotNull(clone);
+    }
+}


### PR DESCRIPTION
Replace the dummy JpegMetaData with our own implementation. For now just an empty class with no specific LS properties.