### PR TITLE
Update version to 0.4.1 and NuGet packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.4.1 - 2025-8-10]
 
 ### Changed
 
-- Updated the project format from .sln to the new .snlx format (requires .NET SDK 9.0.200 and/or Visual Studio 2022 17.13).
+- Updated the project format from .sln to the new .snlx format (requires .NET SDK 9.0.200 or newer and/or Visual Studio 2022 17.14 or newer).
 - Updated to xUnit.net V3.
 - Switched to the artifacts output directory model.
 - Updated NuGet dependencies to the latest released versions.
+  Resolves the issue that SixLabors.ImageSharp 3.1.7 has a known moderate severity vulnerability.
 - The project now conforms to the REUSE guidelines.
+- Add support for AOT compilation in .NET 8.0 and later.
 
 ## [0.4.0 - 2024-11-28]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.4.1 - 2025-8-10]
+## [0.4.1 - 2025-08-10]
 
 ### Changed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,9 +19,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <!-- Version information -->
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <AssemblyVersion>0.4.0.0</AssemblyVersion>
-    <FileVersion>0.4.0.0</FileVersion>
+    <FileVersion>0.4.1.0</FileVersion>
     <Copyright>Copyright 2024 Team CharLS</Copyright>
 
     <!-- Build -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
   <ItemGroup>
     <PackageVersion Include="CharLS.Managed" Version="0.8.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="xunit.v3" Version="2.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageVersion Include="xunit.v3" Version="3.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A sample application is included in the GitHub repository that demonstrates how 
  git clone https://github.com/team-charls/charls-dotnet-imagesharp.git
 ```
 
-* Use the .NET 9.0 CLI or Visual Studio 2022 (v17.12 or newer) to build the solution file CharLSDotNet.sln.  
+* Use the .NET 9.0 CLI or Visual Studio 2022 (v17.14 or newer) to build the solution file CharLSDotNet.slnx.  
  For example: `dotnet build && dotnet test && dotnet publish` to build the NuGet package.  
  Building can be done on all supported .NET SDK platforms: Windows, Linux or macOS
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.4.0   | :white_check_mark: |
+| 0.4.1   | :white_check_mark: |
+| 0.4.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/src/CharLS.Managed.ImageSharp.csproj
+++ b/src/CharLS.Managed.ImageSharp.csproj
@@ -9,6 +9,7 @@
     <!-- Use strong naming -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>CharLS.Managed.ImageSharp.KeyPair.snk</AssemblyOriginatorKeyFile>
+    <IsAotCompatible>true</IsAotCompatible>
 
     <!-- Configure NuGet package settings  -->
     <Company>Team CharLS</Company>

--- a/src/JpegLSConfigurationModule.cs
+++ b/src/JpegLSConfigurationModule.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2024 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 using SixLabors.ImageSharp.Formats;

--- a/src/JpegLSEncoderCore.cs
+++ b/src/JpegLSEncoderCore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Team CharLS.
+// SPDX-FileCopyrightText: © 2024 Team CharLS
 // SPDX-License-Identifier: BSD-3-Clause
 
 using System.Runtime.InteropServices;

--- a/src/JpegLSEncoderCore.cs
+++ b/src/JpegLSEncoderCore.cs
@@ -30,13 +30,13 @@ internal static class JpegLSEncoderCore
         {
             8 => 1,
             24 => 3,
-            _ => throw new UnknownImageFormatException("Unsupported pixel format."),
+            _ => throw new UnknownImageFormatException("Unsupported pixel format.")
         };
 
     private static InterleaveMode GetInterleaveMode(Image image)
     => image.PixelType.BitsPerPixel switch
     {
         24 => InterleaveMode.Sample,
-        _ => InterleaveMode.None,
+        _ => InterleaveMode.None
     };
 }

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@
 # CharLS.Managed.ImageSharp .NET
 
 CharLS.Managed.ImageSharp .NET is a JPEG-LS codec plug-in for the SixLabors.ImageSharp 2D graphics library.
-It adds the ImageSharp required interfaces to the the CharLs.Managed JPEG-LS library allowing to load and save JPEG-LS files with the ImageSharp graphics library.
+It adds the ImageSharp required interfaces to the CharLs.Managed JPEG-LS library allowing to load and save
+JPEG-LS files with the ImageSharp graphics library.
 
-Detailed information can be found in the readme of the github repository.
+Detailed information can be found in the readme of the GitHub repository.

--- a/src/nuget-release-notes.txt
+++ b/src/nuget-release-notes.txt
@@ -1,2 +1,3 @@
-0.4.0
- - Initial release
+0.4.1
+ - Updated referenced NuGet packages.
+ - Added support for AOT compilation.


### PR DESCRIPTION
Resolves the issue that the reference to SixLabors.ImageSharp 3.1.7 had a known moderate severity vulnerability.